### PR TITLE
standardize arch in bitnami-pkg script

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -48,6 +48,6 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=7-r3
+ENV BITNAMI_IMAGE_VERSION=7-r4
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/rootfs/usr/local/bin/bitnami-pkg
+++ b/7/rootfs/usr/local/bin/bitnami-pkg
@@ -57,6 +57,12 @@ identify_arch() {
     debian-*)
       arch=amd64
       ;;
+    ol-*)
+      arch=x86_64
+      ;;
+    rhel-*)
+      arch=x86_64
+      ;;
     esac
     ;;
   *)


### PR DESCRIPTION
In order to identify the nami modules arch, we will make it depend on the distro