### PR TITLE
Run yum update at first step

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -5,6 +5,7 @@ ENV IMAGE_OS=ol-7
 COPY rootfs /
 
 RUN yum-config-manager --enable ol7_developer_EPEL && \
+    yum update -y && \
     install_packages tar gzip curl ca-certificates sudo procps-ng libaio-devel which && \
     useradd -ms /bin/bash bitnami && \
     mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -50,6 +50,6 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=7-r5
+ENV BITNAMI_IMAGE_VERSION=7-r6
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The base image `oraclelinux:7-slim` is 2 months old, so we will update the base system packages as first step.