### PR TITLE
add IS_BASE_IMAGE env var to circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ jobs:
           RELEASE_SERIES_LIST: "7"
           LATEST_STABLE: "7"
           IMAGE_NAME: oraclelinux-extras
+          IS_BASE_IMAGE: 1
           DOCKER_PROJECT: bitnami
           QUAY_PROJECT: bitnami
           GCLOUD_PROJECT: bitnami-containers


### PR DESCRIPTION
In order to allow [test, build & publish logic](https://github.com/bitnami/test-infra/pull/99/commits/7c665aca049902a94e16e76b94aaad350045fdff) to identify whether this repository holds a base image or not, we are adding a new env var to the circle.yml file