### PR TITLE
Add bsdtar and fix bitnami-pkg

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -6,7 +6,7 @@ COPY rootfs /
 
 RUN yum-config-manager --enable ol7_developer_EPEL ol7_optional_latest && \
     yum upgrade -y && \
-    install_packages tar gzip curl ca-certificates sudo procps-ng libaio-devel which && \
+    install_packages tar gzip curl ca-certificates sudo bsdtar procps-ng libaio-devel which && \
     useradd -ms /bin/bash bitnami && \
     mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
     sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \
@@ -50,6 +50,6 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=7-r30
+ENV BITNAMI_IMAGE_VERSION=7-r31
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -6,7 +6,7 @@ COPY rootfs /
 
 RUN yum-config-manager --enable ol7_developer_EPEL ol7_optional_latest && \
     yum upgrade -y && \
-    install_packages tar gzip curl ca-certificates sudo bsdtar procps-ng libaio-devel which && \
+    install_packages tar gzip curl ca-certificates sudo procps-ng libaio-devel which && \
     useradd -ms /bin/bash bitnami && \
     mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
     sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \

--- a/7/rootfs/usr/local/bin/bitnami-pkg
+++ b/7/rootfs/usr/local/bin/bitnami-pkg
@@ -170,7 +170,7 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-tar xzf $PACKAGE.tar.gz
+bsdtar -xf $PACKAGE.tar.gz
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;

--- a/7/rootfs/usr/local/bin/bitnami-pkg
+++ b/7/rootfs/usr/local/bin/bitnami-pkg
@@ -170,8 +170,11 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-PATH_TO_BSDTAR=$(which bsdtar)
-if [ -x "$PATH_TO_BSDTAR" ]; then
+# If the tarball has too many files, it can trigger a bug
+# in overlayfs when using tar. Install bsdtar in the container image
+# to workaround it. As the overhead is too big (~40 MB), it is not added by 
+# default. Source: https://github.com/coreos/bugs/issues/1095
+if which bsdtar > /dev/null; then
   bsdtar -xf $PACKAGE.tar.gz
 else
   tar xzf $PACKAGE.tar.gz

--- a/7/rootfs/usr/local/bin/bitnami-pkg
+++ b/7/rootfs/usr/local/bin/bitnami-pkg
@@ -170,7 +170,13 @@ if [ "$PACKAGE_SHA256" ]; then
   echo "$PACKAGE_SHA256  $PACKAGE.tar.gz" | sha256sum -c -
 fi
 
-bsdtar -xf $PACKAGE.tar.gz
+PATH_TO_BSDTAR=$(which bsdtar)
+if [ -x "$PATH_TO_BSDTAR" ]; then
+  bsdtar -xf $PACKAGE.tar.gz
+else
+  tar xzf $PACKAGE.tar.gz
+fi
+
 case "$1" in
   install) info "Installing $PACKAGE" ;;
   unpack) info "Unpacking $PACKAGE" ;;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Adds bsdtar to the image and changes bitnami-pkg to use bsdtar to extract tarballs

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Now bigger files should be extractable, avoiding the issue mentioned in https://github.com/coreos/bugs/issues/1095
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

