### PR TITLE
Improve build reliability due to GPG issues

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -26,11 +26,20 @@ RUN cd /tmp && \
     tar xzf nami-$NAMI_VERSION-linux-x64.tar.gz --strip 1 -C /opt/bitnami/nami && \
     rm nami-$NAMI_VERSION-linux-x64.tar.gz
 
-ENV TINI_VERSION=v0.13.2
+ENV GPG_KEY_SERVERS_LIST ha.pool.sks-keyservers.net \
+                         hkp://p80.pool.sks-keyservers.net:80 \
+                         keyserver.ubuntu.com \
+                         hkp://keyserver.ubuntu.com:80 \
+                         pgp.mit.edu
+
+ENV TINI_VERSION=v0.13.2 \
+    TINI_GPG_KEY=595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7
 
 RUN cd /tmp && \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 && \
-    gpg --fingerprint 595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 | grep -q "Key fingerprint = 6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
+    for server in $(shuf -e $GPG_KEY_SERVERS_LIST) ; do \
+        gpg --keyserver "$server" --recv-keys $TINI_GPG_KEY && break || : ; \
+    done && \
+    gpg --fingerprint $TINY_GPG_KEY | grep -q "Key fingerprint = 6380 DC42 8747 F6C3 93FE  ACA5 9A84 159D 7001 A4E5" && \
     curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini.asc -o tini.asc && \
     curl -sSL https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -o /usr/local/bin/tini && \
     gpg --verify tini.asc /usr/local/bin/tini && \
@@ -41,7 +50,9 @@ ENV GOSU_VERSION=1.10 \
     GOSU_GPG_KEY=B42F6819007F00F88E364FD4036A9C25BF357DD4
 
 RUN cd /tmp && \
-  gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $GOSU_GPG_KEY && \
+  for server in $(shuf -e $GPG_KEY_SERVERS_LIST) ; do \
+      gpg --keyserver "$server" --recv-keys $GOSU_GPG_KEY && break || : ; \
+  done && \
   gpg --fingerprint $GOSU_GPG_KEY | grep -q "Key fingerprint = B42F 6819 007F 00F8 8E36  4FD4 036A 9C25 BF35 7DD4" && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc -o gosu.asc && \
   curl -sSL https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64 -o /usr/local/bin/gosu && \
@@ -50,6 +61,6 @@ RUN cd /tmp && \
   rm gosu.asc
 
 ENV PATH=/opt/bitnami/nami/bin:$PATH
-ENV BITNAMI_IMAGE_VERSION=7-r63
+ENV BITNAMI_IMAGE_VERSION=7-r64
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fixes issues building the image because of random failures checking GPG keys.

Examples of failing builds because of this issue:

- https://circleci.com/gh/bitnami/oraclelinux-extras/157
- https://circleci.com/gh/bitnami/oraclelinux-extras/150
- https://circleci.com/gh/bitnami/oraclelinux-extras/148