### PR TITLE
Add Deprecation Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![CircleCI](https://circleci.com/gh/bitnami/oraclelinux-extras.svg?style=svg)](https://circleci.com/gh/bitnami/oraclelinux-extras)
 
+# DEPRECATION NOTICE
+
+This image has been deprecated, and will no longer be maintained and updated. Please consider using [oraclelinux](https://hub.docker.com/_/oraclelinux) instead.
+
 # `bitnami/oraclelinux-extras`
 
 ## TL;DR


### PR DESCRIPTION
**Description of the change**

- Add 'Deprecation' Note
- `bitnami/oraclelinux-extras` is no longer maintained and we'll build our container catalog based on `oraclelinux`.
